### PR TITLE
actions/checkout@v4パッケージの内容を最新化

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
actions/checkoutのパッケージが@v2を使っていたので、最新である@v4を使うように変更。