### PR TITLE
PRのタイトルとBodyを取得する方法の変更

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,6 +30,3 @@ jobs:
           if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
             npm run generate-docs
           fi
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}

--- a/generate-docs.js
+++ b/generate-docs.js
@@ -8,12 +8,13 @@ const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
 console.log(eventData)
 
 // プルリクエストの情報を取得
-//const prTitle = eventData.pull_request.title;
-console.log(process.env.PR_TITLE)
-console.log(process.env.PR_BODY)
-//const prBody = eventData.pull_request.body;
-//console.log(prBody)
-const commits = eventData.commits.map(commit => commit.message);
-console.log(commits)
+const prTitle = eventData.pull_request.title;
+console.log(prTitle)
+//console.log(process.env.PR_TITLE)
+//console.log(process.env.PR_BODY)
+const prBody = eventData.pull_request.body;
+console.log(prBody)
+//const commits = eventData.commits.map(commit => commit.message);
+//console.log(commits)
 
 // ここで取得した情報を利用してドキュメントを生成するなどの処理を行う


### PR DESCRIPTION
トリガーイベントをpull_request.closedにすることでeventDataからPRとタイトルが取れるようになったので、そちらの方式に変更。