### PR TITLE
生成AIを使ってGithub Actionsに回答結果を出すようにした

### DIFF
--- a/generate-docs.js
+++ b/generate-docs.js
@@ -3,18 +3,20 @@ import fs from 'fs';
 
 // GitHub Actionsが提供する環境変数からイベント情報を読み込む
 const eventPath = process.env.GITHUB_EVENT_PATH;
-console.log(eventPath)
 const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
-console.log(eventData)
 
 // プルリクエストの情報を取得
 const prTitle = eventData.pull_request.title;
-console.log(prTitle)
-//console.log(process.env.PR_TITLE)
-//console.log(process.env.PR_BODY)
 const prBody = eventData.pull_request.body;
-console.log(prBody)
-//const commits = eventData.commits.map(commit => commit.message);
-//console.log(commits)
 
 // ここで取得した情報を利用してドキュメントを生成するなどの処理を行う
+const completion = await openai.chat.completions.create({
+  messages: [
+    { "role": "system", "content": "プルリクエストのタイトルおよび本文から、エンドユーザー向けに最適化されたリリースノートを生成してください。技術的な表現や開発者向けの内容が含まれる場合がありますが、エンドユーザーが読んでもわかりやすい文章にしてください。" },
+    { "role": "user", "content": `プルリクエストのタイトルは「${prTitle}、本文は「${prBody}」です。` },
+  ],
+  model: "gpt-3.5-turbo-1106",
+  max_tokens: 150,
+});
+
+console.log(completion.choices[0]);


### PR DESCRIPTION
ユーザ向けリリースノートを作る前にGithub Actions上だけで回答を表示させて、どの程度有用な文章が生成されるか確認できるようにした。

PRのボディに改行が含まれる場合もテスト。