### PR TITLE
生成AIを使ってGithub Actionsに回答結果を出すようにした

### DIFF
--- a/generate-docs.js
+++ b/generate-docs.js
@@ -10,7 +10,7 @@ const prTitle = eventData.pull_request.title;
 const prBody = eventData.pull_request.body;
 
 // ここで取得した情報を利用してドキュメントを生成するなどの処理を行う
-const completion = await openai.chat.completions.create({
+const completion = await OpenAiSource.chat.completions.create({
   messages: [
     { "role": "system", "content": "プルリクエストのタイトルおよび本文から、エンドユーザー向けに最適化されたリリースノートを生成してください。技術的な表現や開発者向けの内容が含まれる場合がありますが、エンドユーザーが読んでもわかりやすい文章にしてください。" },
     { "role": "user", "content": `プルリクエストのタイトルは「${prTitle}、本文は「${prBody}」です。` },


### PR DESCRIPTION
ユーザ向けリリースノートを作る前にGithub Actions上だけで回答を表示させて、どの程度有用な文章が生成されるか確認できるようにした。

PRのボディに改行が含まれる場合もテスト。